### PR TITLE
Fixing zone_redundant variable

### DIFF
--- a/service-bus.tf
+++ b/service-bus.tf
@@ -7,7 +7,7 @@ module "servicebus-namespace" {
   env                 = var.env
   common_tags         = local.tags
   sku                 = var.sku
-  zoneRedundant       = (var.sku != "Premium" ? "false" : "true")
+  zone_redundant       = (var.sku != "Premium" ? "false" : "true")
 }
 
 module "servicebus-queue-request" {

--- a/state.tf
+++ b/state.tf
@@ -14,7 +14,7 @@ terraform {
      }
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 2.57.0"       # AzureRM provider version
+      version = "~> 2.99.0"       # AzureRM provider version
     }
   }
 }


### PR DESCRIPTION
### Change description ###
The `zoneRedundant` variable has been update to `zone_redundant` to follow the correct way to name variables in terraform 

https://www.terraform-best-practices.com/naming#general-conventions



**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No