### PR TITLE
DTSPO-6371 - add private endpoint provider to service bus module

### DIFF
--- a/appinsights.tf
+++ b/appinsights.tf
@@ -1,8 +1,8 @@
 resource "azurerm_application_insights" "appinsights" {
   name                = "${var.product}-${var.env}"
   location            = var.location
-  resource_group_name = "${azurerm_resource_group.rg.name}"
-  application_type    = "${var.application_type}"
+  resource_group_name = azurerm_resource_group.rg.name
+  application_type    = var.application_type
 
   lifecycle {
     ignore_changes = [
@@ -14,12 +14,12 @@ resource "azurerm_application_insights" "appinsights" {
 }
 
 output "appInsightsInstrumentationKey" {
-  value = "${azurerm_application_insights.appinsights.instrumentation_key}"
+  value     = azurerm_application_insights.appinsights.instrumentation_key
   sensitive = true
 }
 
 resource "azurerm_key_vault_secret" "app_insights_key" {
   name         = "AppInsightsInstrumentationKey"
-  value        = "${azurerm_application_insights.appinsights.instrumentation_key}"
-  key_vault_id = "${module.vault.key_vault_id}"
+  value        = azurerm_application_insights.appinsights.instrumentation_key
+  key_vault_id = module.vault.key_vault_id
 }

--- a/key-vault.tf
+++ b/key-vault.tf
@@ -1,16 +1,16 @@
 module "vault" {
-  source              = "git@github.com:hmcts/cnp-module-key-vault?ref=master"
-  name                = "${var.product}-${var.env}"
-  product             = var.product
-  env                 = var.env
-  tenant_id           = var.tenant_id
-  object_id           = var.jenkins_AAD_objectId
-  resource_group_name = azurerm_resource_group.rg.name
-  product_group_name  = "dcd_ccd"
-  common_tags         = "${local.tags}"
+  source                  = "git@github.com:hmcts/cnp-module-key-vault?ref=master"
+  name                    = "${var.product}-${var.env}"
+  product                 = var.product
+  env                     = var.env
+  tenant_id               = var.tenant_id
+  object_id               = var.jenkins_AAD_objectId
+  resource_group_name     = azurerm_resource_group.rg.name
+  product_group_name      = "dcd_ccd"
+  common_tags             = local.tags
   create_managed_identity = true
 }
-  
+
 data "azurerm_key_vault" "s2s_vault" {
   name                = "s2s-${var.env}"
   resource_group_name = "rpe-service-auth-provider-${var.env}"
@@ -26,7 +26,7 @@ resource "azurerm_key_vault_secret" "hmc_cft_hearing_service_s2s_secret" {
   value        = data.azurerm_key_vault_secret.hmc_cft_hearing_service_s2s_key.value
   key_vault_id = module.vault.key_vault_id
 }
-  
+
 data "azurerm_key_vault_secret" "hmc_hmi_inbound_adapter_s2s_key" {
   name         = "microservicekey-hmc-hmi-inbound-adapter"
   key_vault_id = data.azurerm_key_vault.s2s_vault.id
@@ -50,9 +50,9 @@ resource "azurerm_key_vault_secret" "api_gw_s2s_secret" {
 }
 
 output "vaultName" {
-  value = "${module.vault.key_vault_name}"
+  value = module.vault.key_vault_name
 }
 
 output "vaultUri" {
-  value = "${module.vault.key_vault_uri}"
+  value = module.vault.key_vault_uri
 }

--- a/main.tf
+++ b/main.tf
@@ -1,18 +1,18 @@
 
 locals {
-  tags = "${merge(
+  tags = (merge(
     var.common_tags,
     tomap({
       "Team Contact" = var.team_contact
-      "Destroy Me" = var.destroy_me
+      "Destroy Me"   = var.destroy_me
     })
-  )}"
+  ))
 }
 
 // Shared Resource Group
 resource "azurerm_resource_group" "rg" {
   name     = "${var.product}-shared-${var.env}"
-  location = "${var.location}"
+  location = var.location
 
-  tags = "${local.tags}"
+  tags = local.tags
 }

--- a/service-bus.tf
+++ b/service-bus.tf
@@ -1,5 +1,8 @@
 
 module "servicebus-namespace" {
+  providers = {
+    azurerm.private-endpoint = azurerm.private-endpoint
+  }
   source              = "git@github.com:hmcts/terraform-module-servicebus-namespace?ref=master"
   name                = "${var.product}-servicebus-${var.env}"
   resource_group_name = azurerm_resource_group.rg.name
@@ -7,45 +10,45 @@ module "servicebus-namespace" {
   env                 = var.env
   common_tags         = local.tags
   sku                 = var.sku
-  zone_redundant       = (var.sku != "Premium" ? "false" : "true")
+  zone_redundant      = (var.sku != "Premium" ? "false" : "true")
 }
 
 module "servicebus-queue-request" {
-  source                = "git@github.com:hmcts/terraform-module-servicebus-queue?ref=master"
-  name                  = "${var.product}-to-hmi-${var.env}"
-  namespace_name        = module.servicebus-namespace.name
-  resource_group_name   = azurerm_resource_group.rg.name
+  source              = "git@github.com:hmcts/terraform-module-servicebus-queue?ref=master"
+  name                = "${var.product}-to-hmi-${var.env}"
+  namespace_name      = module.servicebus-namespace.name
+  resource_group_name = azurerm_resource_group.rg.name
 }
 
 module "servicebus-queue-response" {
-  source                = "git@github.com:hmcts/terraform-module-servicebus-queue?ref=master"
-  name                  = "${var.product}-from-hmi-${var.env}"
-  namespace_name        = module.servicebus-namespace.name
-  resource_group_name   = azurerm_resource_group.rg.name
+  source              = "git@github.com:hmcts/terraform-module-servicebus-queue?ref=master"
+  name                = "${var.product}-from-hmi-${var.env}"
+  namespace_name      = module.servicebus-namespace.name
+  resource_group_name = azurerm_resource_group.rg.name
 }
 
 output "sb_primary_send_and_listen_connection_string" {
-  value = module.servicebus-namespace.primary_send_and_listen_connection_string
+  value     = module.servicebus-namespace.primary_send_and_listen_connection_string
   sensitive = true
 }
 
 resource "azurerm_key_vault_secret" "servicebus_primary_connection_string" {
-  name      = "hmc-servicebus-connection-string"
-  value     = module.servicebus-namespace.primary_send_and_listen_connection_string
-  key_vault_id = "${module.vault.key_vault_id}"
+  name         = "hmc-servicebus-connection-string"
+  value        = module.servicebus-namespace.primary_send_and_listen_connection_string
+  key_vault_id = module.vault.key_vault_id
 }
 
 module "servicebus-topic" {
-  source                = "git@github.com:hmcts/terraform-module-servicebus-topic?ref=master"
-  name                  = "${var.product}-to-cft-${var.env}"
-  namespace_name        = module.servicebus-namespace.name
-  resource_group_name   = azurerm_resource_group.rg.name
+  source              = "git@github.com:hmcts/terraform-module-servicebus-topic?ref=master"
+  name                = "${var.product}-to-cft-${var.env}"
+  namespace_name      = module.servicebus-namespace.name
+  resource_group_name = azurerm_resource_group.rg.name
 }
 
 module "servicebus-subscription" {
-  source                = "git@github.com:hmcts/terraform-module-servicebus-subscription?ref=master"
-  name                  = "${var.product}-subs-to-cft-${var.env}"
-  namespace_name        = module.servicebus-namespace.name
-  topic_name            = module.servicebus-topic.name
-  resource_group_name   = azurerm_resource_group.rg.name
+  source              = "git@github.com:hmcts/terraform-module-servicebus-subscription?ref=master"
+  name                = "${var.product}-subs-to-cft-${var.env}"
+  namespace_name      = module.servicebus-namespace.name
+  topic_name          = module.servicebus-topic.name
+  resource_group_name = azurerm_resource_group.rg.name
 }

--- a/service-bus.tf
+++ b/service-bus.tf
@@ -1,7 +1,7 @@
 
 module "servicebus-namespace" {
   providers = {
-    azurerm.private-endpoint = azurerm.private-endpoint
+    azurerm.private_endpoint = azurerm.private_endpoint
   }
   source              = "git@github.com:hmcts/terraform-module-servicebus-namespace?ref=master"
   name                = "${var.product}-servicebus-${var.env}"

--- a/state.tf
+++ b/state.tf
@@ -2,8 +2,15 @@ provider "azurerm" {
   features {}
 }
 
+provider "azurerm" {
+  features {}
+  skip_provider_registration = true
+  alias                      = "private-endpoint"
+  subscription_id            = var.aks_subscription_id
+}
+
 terraform {
-  required_version = ">= 0.15"  # Terraform client version
+  required_version = ">= 0.15" # Terraform client version
 
   backend "azurerm" {}
 
@@ -11,10 +18,10 @@ terraform {
     azuread = {
       source  = "hashicorp/azuread"
       version = "1.6.0"
-     }
+    }
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 2.99.0"       # AzureRM provider version
+      version = "~> 2.99.0" # AzureRM provider version
     }
   }
 }

--- a/state.tf
+++ b/state.tf
@@ -5,7 +5,7 @@ provider "azurerm" {
 provider "azurerm" {
   features {}
   skip_provider_registration = true
-  alias                      = "private-endpoint"
+  alias                      = "private_endpoint"
   subscription_id            = var.aks_subscription_id
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -1,12 +1,12 @@
 //SHARED VARIABLES
 variable "product" {
-  type = string
+  type        = string
   description = "The name of your application"
-  default = "hmc"
+  default     = "hmc"
 }
 
 variable "env" {
-  type = string
+  type        = string
   description = "The deployment environment (sandbox, aat, prod etc..)"
 }
 
@@ -15,9 +15,9 @@ variable "subscription" {
 }
 
 variable "location" {
-  type    = string
+  type        = string
   description = "The location where you would like to deploy your infrastructure"
-  default = "UK South"
+  default     = "UK South"
 }
 
 variable "tenant_id" {
@@ -29,14 +29,14 @@ variable "jenkins_AAD_objectId" {
 }
 
 variable "application_type" {
-  type = string
-  default = "web"
+  type        = string
+  default     = "web"
   description = "Type of Application Insights (Web/Other)"
 }
 
 // TAG SPECIFIC VARIABLES
 variable "common_tags" {
-  type = map
+  type = map(any)
 }
 
 variable "team_contact" {
@@ -52,7 +52,9 @@ variable "destroy_me" {
 }
 
 variable "sku" {
-  type = string
-  default = "Standard"
+  type        = string
+  default     = "Standard"
   description = "SKU type(Basic, Standard and Premium)"
 }
+
+variable "aks_subscription_id" {}


### PR DESCRIPTION
JIRA link (if applicable)
[tools.hmcts.net/jira/browse/DTSPO-6371](https://tools.hmcts.net/jira/browse/DTSPO-6371)

Change description
PlatOps have made some changes to the service bus terraform module, mainly around adding the ability to enable private endpoints. We needed to add a Private Endpoint provider to allow for Private endpoints being deployed to a different Subscription to the Service Bus being created.

This change should have no effect on anything currently deployed, but it will allow you to deploy a Service Bus with a Private Endpoint if you add the correct inputs to the module.

More information on that can be found here: [hmcts/terraform-module-servicebus-namespace#usage](https://github.com/hmcts/terraform-module-servicebus-namespace#usage)

Does this PR introduce a breaking change? (check one with "x")

[ ] Yes
[x] No