### PR TITLE
Store app insights connection string

### DIFF
--- a/appinsights.tf
+++ b/appinsights.tf
@@ -20,6 +20,12 @@ output "appInsightsInstrumentationKey" {
 }
 
 resource "azurerm_key_vault_secret" "app_insights_key" {
+  name         = "app-insights-connection-string"
+  value        = azurerm_application_insights.appinsights.connection_string
+  key_vault_id = module.vault.key_vault_id
+}
+
+resource "azurerm_key_vault_secret" "app_insights_key" {
   name         = "AppInsightsInstrumentationKey"
   value        = azurerm_application_insights.appinsights.instrumentation_key
   key_vault_id = module.vault.key_vault_id

--- a/appinsights.tf
+++ b/appinsights.tf
@@ -19,7 +19,7 @@ output "appInsightsInstrumentationKey" {
   sensitive = true
 }
 
-resource "azurerm_key_vault_secret" "app_insights_key" {
+resource "azurerm_key_vault_secret" "connection_string" {
   name         = "app-insights-connection-string"
   value        = azurerm_application_insights.appinsights.connection_string
   key_vault_id = module.vault.key_vault_id

--- a/state.tf
+++ b/state.tf
@@ -21,7 +21,7 @@ terraform {
     }
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "3.40.0" # AzureRM provider version
+      version = "3.69.0" # AzureRM provider version
     }
   }
 }

--- a/state.tf
+++ b/state.tf
@@ -21,7 +21,7 @@ terraform {
     }
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "3.69.0" # AzureRM provider version
+      version = "3.40.0" # AzureRM provider version
     }
   }
 }

--- a/state.tf
+++ b/state.tf
@@ -21,7 +21,7 @@ terraform {
     }
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.2.0" # AzureRM provider version
+      version = "3.69.0" # AzureRM provider version
     }
   }
 }


### PR DESCRIPTION
Blocking prod upgrade:

```
  Warning  FailedMount  11m (x55 over 107m)   kubelet  MountVolume.SetUp failed for volume "vault-fis-kv" : rpc error: code = Unknown desc = failed to mount secrets store objects for pod fis/fis-hmc-api-java-5ddf68569c-c8pcm, err: rpc error: code = Unknown desc = failed to mount objects, error: failed to get objectType:secret, objectName:app-insights-connection-string, objectVersion:: keyvault.BaseClient#GetSecret: Failure responding to request: StatusCode=404 -- Original Error: autorest/azure: Service returned an error. Status=404 Code="SecretNotFound" Message="A secret with (name/id) app-insights-connection-string was not found in this key vault. If you recently deleted this secret you may be able to recover it using the correct recovery command. For help resolving this issue, please see https://go.microsoft.com/fwlink/?linkid=2125182"
```